### PR TITLE
Update to remove the channel to the merkle tree building

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,105 @@
 # SMT
 
-Stateful Merkle Trees provide the support for building and maintaining information in multiple ordered and distributed blockchains.
+Stateful Merkle Trees provide the support for  building and maintaining
+information in Merkle Trees.  On the face of this, SMT isn't very different
+from how Merkle Trees have been used in blockchains since Bitcoin.  However,
+SMT allows a blockchain to maintain Merkle Trees spanning many blocks, and
+even Merkle Trees of Merkle Trees.
 
-The SMT implementation is a layered one:
+An SMT can collect hashes of validated data from multiple sources and
+create a Merkle Tree that orders all these hashes by arrival time to the
+SMT.  The order of all sources is maintained.
 
-* SMT  
-  * Construction: collect hashes and add to Merkle Tree
-  * Build: Time Stamping, block building
-  * Persistence: Record entries, Merkle States to the database
-  * Validation: Validate entries to be added to the Merkle Tree
+An additional feature is the ability to order entries into blocks, but
+allow the Merkle Tree to span blocks. This means that all the data collected
+is in fact organized into a single Merkle Tree, but sets of entries
+are understood to represent blocks.
+
+SMT goes further, and allows Merkle Trees to be maintained over time, but
+anchored into parent Merkle Trees. In other words, SMT allows validators to
+submit hashes of validated entries into SMT and maintain those entries in
+their own Merkle Trees that, on block boundaries, are anchored into other
+Merkle Trees, building a Hierarchical set of Merkle Trees,  or a Merkle Tree
+of Merkle trees.
+
+A single Merkle Tree for example could take as elements the letters of the
+Alphabet.  In this notation, a and b represent hashes, and ab represents
+some set of hashing of a and b.  Because we combine hashes on power of 2
+boundaries, we can understand how any set of characters is combined.
+
+for example, abcdefgh is h( h( h(a+b), h(c+d) ), h( h(e,f), h(g,h) ) )
+
+```
+a  b  c  d  e  f  g  h  i  j  k  l  m  n  o  p  q  r  s  t  u  v  w  x  y  z
+  ab    cd    ef    gh    ij    kl    mn    op    qr    st    uv    wx   [yz]
+      abcd        efgh        ijkl        mnop        qrst        uvwx
+              abcdefgh                ijklmnop               [qrstuvwx]
+                             [abcdefghijklmnop] 
+```
+
+The roots of this tree are **abcdefghijklmnop**, **qrstuvwx**, and **yz**.
+Given a hash function h(x), and a concatenation
+operator +, The DAG root of the above partial Merkle Tree is
+
+> h(abcdefghijklmnop + h([qrstuvwx] + [yz]))
+
+In order to create blocks, suppose the alphabet were entered into a
+blockchain that managed 5 elements per block (and we put any leftovers in
+their own block).  Then the above blockchain of characters becomes a Merkle
+tree split up as follows, with each block labeled d0-d5:
+
+```
+a b c d e    f g h i j     k l m n o          p q r s t     u v w x y    z
+ ab  cd |   ef  gh  ij      kl  mn |         op  qr  st      uv  wx |   yz
+   abcd |     efgh   |    ijkl     |       mnop    qrst        uvwx |    |
+        | abcdefgh   |             |     ijklmnop     |    qrstuvwx |    |
+        |            |             | abcdefghijklmnop |             |    |
+        |            |             |                  |             |    |
+       d0           d1            d2                 d3            d4   d5
+```
+
+Note that we end up with six blocks, with the following elements:
+
+* a b c d e
+* f g h i j
+* k l m n o
+* p q r s t
+* u v w x y
+* z
+
+Also note that each block has a DAG root. Consider the DAG roots below,
+labeled d0 to d5 as follows:
+
+* d0 = h(abcd+e)
+* d1 = h(abcdefgh + ij)
+* d2 = h(abcdefgh + h(ijkl + h(mn+o)))
+* d3 = h(abcdefghijklmnop +qrst)
+* d4 = h(abcdefghijklmnop + h(qrstuvwx + y))
+* d5 = h(abcdefghijklmnop + h(qrstuvwx + yz)
+
+Now we can construct a Merkle Tree that takes as elements the roots of a set
+of merkle trees.  Further note that regardless of the rules for constructing
+blocks, any blockchain can fit within a Merkle Tree rather than fitting
+Merkle Trees into blocks, using the method described above.
+
+So suppose that we have not just d0-d5, but e0-e5, f0-f5, and g0-g5 where d,
+e,f,g all represent DAG Roots of merkle trees.  We can build a root Merkle
+Tree that would take these elements:
+
+```
+d0 e0 f0 g0  d1 e1 f1 g1  d2 e2 f2 g2      d3 e3 f3 g3  d4 e4 f4 g4  d5 e5 f5 g5
+ d0e0  f0g0   d1e1  f1g1   d2e2  f2g2       d3e3  f3g3   d4e4  f4g4   d5e5  f5g5
+   d0e0f0g0     d1e1f1g1     d2e2f2g2         d3e3f3g3     d4e4f4g4     d5e5f5g5
+        d0e0f0g0d1e1f1g1              d2e2f2g2d3e3f3g3          d4e4f4g4d5e5f5g5
+                      d0e0f0g0d1e1f1g1d2e2f2g2d3e3f3g3
+```
+
+Due to the limitations of a document like this, flushing out how deep the
+merkle trees can be nested will not be illustrated.  If the
+root MerKle Tree can hold the DAGs of other Merkle Trees, those Merkle Trees
+can also hold DAGS of other Merkle Trees.
   
-## SMT
+## SMT API
 * `func NewSMT() SMT`
   
    create a new SMT object to manage a Merkle tree   

--- a/smt/helper.go
+++ b/smt/helper.go
@@ -11,6 +11,7 @@
 package smt
 
 import (
+	"encoding/binary"
 	"os"
 	"os/user"
 )
@@ -144,4 +145,24 @@ func Int64Bytes(i int64) []byte {
 func BytesInt64(data []byte) (int64, []byte) {
 	return int64(data[0])<<56 + int64(data[1])<<48 + int64(data[2])<<40 + int64(data[3])<<32 +
 		int64(data[4])<<24 + int64(data[5])<<16 + int64(data[6])<<8 + int64(data[7]), data[8:]
+}
+
+// SliceBytes
+// Append a Uvarint length infront of a slice, effectively converting a slice to a counted string
+func SliceBytes(slice []byte) []byte {
+	var varInt [8]byte                                        // Buffer to hold a Uvarint
+	count := binary.PutUvarint(varInt[:], uint64(len(slice))) // calculate the Uvarint of the len of the slice
+	counted := append(varInt[:count], slice...)               // Now put the Uvarint right in front of the slice
+	return counted                                            // Return the resulting counted string
+}
+
+// BytesSlice
+// Convert a counted byte array (which is a count followed by the byte values) to a slice.  We return what is
+// left of the data once the counted byte array is removed
+func BytesSlice(data []byte) (slice []byte, data2 []byte) {
+	value, count := binary.Uvarint(data) // Get the number of bytes in the slice, and count of bytes used for the count
+	data = data[count:]
+	slice = append(slice, data[:value]...)
+	data = data[value:]
+	return slice, data
 }

--- a/smt/helper_test.go
+++ b/smt/helper_test.go
@@ -1,0 +1,43 @@
+package smt
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+func TestSliceBytes(t *testing.T) {
+	for i := 0; i < 1024; i++ {
+		var bytetest []byte
+		for j := 0; j < i; j++ {
+			bytetest = append(bytetest, byte(rand.Int()))
+		}
+		counted := SliceBytes(bytetest)
+		slice, left := BytesSlice(counted)
+
+		if len(left) > 0 || !bytes.Equal(bytetest, slice) {
+			t.Errorf(" %d %x %x", len(left), bytetest, slice)
+		}
+	}
+
+	var tests [][]byte
+	var inputs []byte
+	for i := 0; i < 1024; i++ {
+		var bytetest []byte
+		for j := 0; j < i; j++ {
+			bytetest = append(bytetest, byte(rand.Int()))
+		}
+		tests = append(tests, bytetest)
+		counted := SliceBytes(bytetest)
+		inputs = append(inputs, counted...)
+	}
+
+	for i, v := range tests {
+		var slice []byte
+		slice, inputs = BytesSlice(inputs)
+
+		if !bytes.Equal(v, slice) {
+			t.Errorf(" %d %x %x", i, v, slice)
+		}
+	}
+}

--- a/smt/merklestate.go
+++ b/smt/merklestate.go
@@ -21,13 +21,10 @@ import (
 // Interestingly, the state of building such a Merkle Tree looks just like counting in binary.  And the
 // higher order bits set will correspond to where the binary roots must be kept in a Merkle state.
 type MerkleState struct {
-	Name         []byte                 // Name of this MerkleState
-	Key          [16]byte               // Key for this MerkleState
 	HashFunction func(data []byte) Hash // Hash function for this Merkle State
 	Count        int64                  // Count of hashes added to the Merkle tree
 	Pending      []*Hash                // Array of hashes that represent the left edge of the Merkle tree
 	HashList     []Hash                 // List of Hashes in the order added to the chain
-	HashFeed     chan *Hash             // Feed of hashes to add to the MerkleState
 }
 
 // String
@@ -136,7 +133,6 @@ func (m MerkleState) Equal(m2 MerkleState) (errorFlag bool) {
 // Marshal
 // Encodes the Merkle State so it can be embedded into the Merkle Tree
 func (m *MerkleState) Marshal() (MSBytes []byte) {
-	MSBytes = append(MSBytes, SliceBytes(m.Name)...)  // Record the name of the Merkle Tree
 	MSBytes = append(MSBytes, Int64Bytes(m.Count)...) // Count
 	cnt := m.Count                                    // Each bit set in Count, indicates a Sub Merkle Tree root
 	for i := 0; cnt > 0; i++ {                        // For each bit in cnt,
@@ -157,7 +153,6 @@ func (m *MerkleState) Marshal() (MSBytes []byte) {
 // in this instance of MSMarshal to the state defined by MSBytes.  It is assumed that the
 // hash function has been set by the caller.
 func (m *MerkleState) UnMarshal(MSBytes []byte) {
-	m.Name, MSBytes = BytesSlice(MSBytes)  // Extract the MerkleState name
 	m.Count, MSBytes = BytesInt64(MSBytes) // Extract the Count
 	m.Pending = m.Pending[:0]              // Set Pending to zero, then use the bits of Count
 	cnt := m.Count                         //   to guide the extraction of the List of Sub Merkle State roots

--- a/smt/merklestate.go
+++ b/smt/merklestate.go
@@ -136,6 +136,7 @@ func (m MerkleState) Equal(m2 MerkleState) (errorFlag bool) {
 // Marshal
 // Encodes the Merkle State so it can be embedded into the Merkle Tree
 func (m *MerkleState) Marshal() (MSBytes []byte) {
+	MSBytes = append(MSBytes, SliceBytes(m.Name)...)  // Record the name of the Merkle Tree
 	MSBytes = append(MSBytes, Int64Bytes(m.Count)...) // Count
 	cnt := m.Count                                    // Each bit set in Count, indicates a Sub Merkle Tree root
 	for i := 0; cnt > 0; i++ {                        // For each bit in cnt,
@@ -156,7 +157,7 @@ func (m *MerkleState) Marshal() (MSBytes []byte) {
 // in this instance of MSMarshal to the state defined by MSBytes.  It is assumed that the
 // hash function has been set by the caller.
 func (m *MerkleState) UnMarshal(MSBytes []byte) {
-
+	m.Name, MSBytes = BytesSlice(MSBytes)  // Extract the MerkleState name
 	m.Count, MSBytes = BytesInt64(MSBytes) // Extract the Count
 	m.Pending = m.Pending[:0]              // Set Pending to zero, then use the bits of Count
 	cnt := m.Count                         //   to guide the extraction of the List of Sub Merkle State roots

--- a/smt/receipt.go
+++ b/smt/receipt.go
@@ -226,6 +226,7 @@ func (r *Receipt) String() string {
 // Note that the element must be added to the Merkle Tree before the anchor, but the anchor can be any element
 // after the element, or even the element itself.
 func GetReceipt(manager *MerkleManager, element Hash, anchor Hash) *Receipt {
+	manager.DBManager.EndBatch()                 // Make sure all batched writes are flushed to disk
 	elementIndex := manager.GetIndex(element[:]) // Get the index of the element in the Merkle Tree; -1 if not found
 	anchorIndex := manager.GetIndex(anchor[:])   // Get the index of the anchor in the Merkle Tree; -1 if not found
 	if elementIndex == -1 || anchorIndex == -1 { // Both the element and the anchor must be in the Merkle Tree

--- a/smt/receipt_test.go
+++ b/smt/receipt_test.go
@@ -32,7 +32,7 @@ func TestReceipt(t *testing.T) {
 	// populate the database
 	for i := 0; i < testMerkleTreeSize; i++ {
 		v := GetHash(i)
-		manager.HashFeed <- v
+		manager.AddHash(v)
 		fmt.Printf("e%-6d %x %v\n", i, v, v[:3])
 	}
 	e0 := GetHash(0)
@@ -59,9 +59,6 @@ func TestReceipt(t *testing.T) {
 	fmt.Printf("         %3v                %3v                  %3v\n", e01[:3], e23[:3], e45[:3])
 	fmt.Printf("                       %3v\n", e0123[:3])
 
-	for len(manager.HashFeed) > 0 {
-		time.Sleep(time.Millisecond)
-	}
 	element := GetHash(0)
 	anchor := GetHash(3)
 
@@ -88,11 +85,7 @@ func TestReceiptAll(t *testing.T) {
 	// populate the database
 	for i := 0; i < testMerkleTreeSize; i++ {
 		v := GetHash(i)
-		manager.HashFeed <- v
-	}
-
-	for len(manager.HashFeed) > 0 {
-		time.Sleep(time.Millisecond)
+		manager.AddHash(v)
 	}
 
 	for i := -10; i < testMerkleTreeSize+10; i++ {
@@ -152,17 +145,13 @@ func PopulateDatabase(manager *MerkleManager, treeSize int64) {
 	startCount := manager.MS.Count
 	for i := startCount; i < treeSize; i++ {
 		v := GetHash(int(i))
-		manager.HashFeed <- v
+		manager.AddHash(v)
 		if i%100000 == 0 {
 			seconds := time.Now().Sub(start).Seconds() + 1
 			fmt.Println(
 				"Entries added ", humanize.Comma(i),
 				" at ", (i-startCount)/int64(seconds), " per second.")
 		}
-	}
-
-	for len(manager.HashFeed) > 0 {
-		time.Sleep(time.Millisecond)
 	}
 }
 

--- a/storage/database/manager_test.go
+++ b/storage/database/manager_test.go
@@ -47,23 +47,23 @@ func writeAndRead(t *testing.T, dbManager *database.Manager) {
 	d1 := []byte{1, 2, 3}
 	d2 := []byte{2, 3, 4}
 	d3 := []byte{3, 4, 5}
-	_ = dbManager.Put("a", []byte("horse"), d1)
-	_ = dbManager.Put("b", []byte("horse"), d2)
-	_ = dbManager.Put("c", []byte("horse"), d3)
-	v1 := dbManager.Get("a", []byte("horse"))
-	v2 := dbManager.Get("b", []byte("horse"))
-	v3 := dbManager.Get("c", []byte("horse"))
+	_ = dbManager.Put("a", "", []byte("horse"), d1)
+	_ = dbManager.Put("b", "", []byte("horse"), d2)
+	_ = dbManager.Put("c", "", []byte("horse"), d3)
+	v1 := dbManager.Get("a", "", []byte("horse"))
+	v2 := dbManager.Get("b", "", []byte("horse"))
+	v3 := dbManager.Get("c", "", []byte("horse"))
 
 	if !bytes.Equal(d1, v1) || !bytes.Equal(d2, v2) || !bytes.Equal(d3, v3) {
 		t.Error("All values should be equal")
 	}
 
-	if err := dbManager.PutInt64("d", []byte(fmt.Sprint(1)), int64(1)); err == nil {
+	if err := dbManager.PutInt64("d", "", []byte(fmt.Sprint(1)), int64(1)); err == nil {
 		t.Error("Should throw an error")
 	}
 
 	for i := 0; i < 10; i++ {
-		if err := dbManager.PutBatch("a", storage.Int64Bytes(int64(i)), []byte(fmt.Sprint(i))); err != nil {
+		if err := dbManager.PutBatch("a", "", storage.Int64Bytes(int64(i)), []byte(fmt.Sprint(i))); err != nil {
 			t.Error(err)
 		}
 	}
@@ -71,7 +71,7 @@ func writeAndRead(t *testing.T, dbManager *database.Manager) {
 
 	// Check that I can read all thousand entries
 	for i := 0; i < 10; i++ {
-		eKey := dbManager.GetKey("a", storage.Int64Bytes(int64(i)))
+		eKey := dbManager.GetKey("a", "", storage.Int64Bytes(int64(i)))
 		eValue := []byte(fmt.Sprint(i))
 
 		fmt.Printf("key %x value %s\n", eKey, eValue)


### PR DESCRIPTION
The user can build a channel to the merkle tree building if they desire.  The problem is that adding it within the SMT library just makes the library unnecessarily complicated.